### PR TITLE
Fix build error when POSIX and runtime is both enabled

### DIFF
--- a/src/runtime/proc_runtime_instructions_POSIX.c
+++ b/src/runtime/proc_runtime_instructions_POSIX.c
@@ -14,7 +14,7 @@ int proc_runtime_unop(proc_instruction_t * instruction);
 int proc_runtime_binop(proc_instruction_t * instruction);
 int proc_runtime_call(proc_instruction_t * instruction, proc_analysis_t ** analysis, proc_t ** proc, int * i, if_else_flag_t * _if_else_flag);
 
-pthread_key_t recursion_depth_key;
+extern pthread_key_t recursion_depth_key;
 
 /**
  * Execute a block instruction.


### PR DESCRIPTION
When building a project with build parameters `csp_proc:posix=true` and `csp_proc:proc_runtime=true`, linking fails with "multiple definition of 'recursion_depth_key';", as this variable is defined in both `runtime/proc_runtime_POSIX.c:26` and `runtime/proc_runtime_instructions_POSIX.c:19`. 

Found as I was integrating csp_proc into [csp-pi-gpio](https://github.com/discosat/csp-pi-gpio):

```
FAILED: app 
cc  -o app app.p/src_main.c.o app.p/src_param_config.c.o app.p/src_hooks.c.o app.p/src_serial.c.o app.p/src_gpio.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,--whole-archive -Wl,--start-group lib/csp/libcsp.a lib/param/libparam.a lib/csp_proc/libcsp_proc.a -Wl,--no-whole-archive -Wl,--export-dynamic -ldl /usr/lib/x86_64-linux-gnu/libyaml.so -lc -pthread /usr/lib/x86_64-linux-gnu/libsocketcan.so /usr/lib/x86_64-linux-gnu/libzmq.so /usr/lib/x86_64-linux-gnu/libbsd.so -Wl,--end-group
/usr/bin/ld: lib/csp_proc/libcsp_proc.a.p/src_runtime_proc_runtime_POSIX.c.o:/home/tobias/git/csp-gpio/builddir/../lib/csp_proc/src/runtime/proc_runtime_POSIX.c:26: multiple definition of `recursion_depth_key'; lib/csp_proc/libcsp_proc.a.p/src_runtime_proc_runtime_instructions_POSIX.c.o:/home/tobias/git/csp-gpio/builddir/../lib/csp_proc/src/runtime/proc_runtime_instructions_POSIX.c:19: first defined here
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

A solution seems to be marking one of the definitions as `extern`
