### PR TITLE
Array access fix

### DIFF
--- a/src/runtime/proc_runtime_instructions_common.c
+++ b/src/runtime/proc_runtime_instructions_common.c
@@ -162,16 +162,19 @@ double float_abs(double x) {
 }
 
 int proc_param_scan_offset(char * arg) {
+	char * arg_copy = proc_strdup(arg);
 	char * saveptr;
 	char * token;
 	int offset = -1;
 
-	strtok_r(arg, "[", &saveptr);
+	strtok_r(arg_copy, "[", &saveptr);
 	token = strtok_r(NULL, "[", &saveptr);
 	if (token != NULL) {
 		sscanf(token, "%d", &offset);
 		*token = '\0';
 	}
+
+	proc_free(arg_copy);
 
 	return offset;
 }

--- a/src/runtime/proc_runtime_instructions_common.c
+++ b/src/runtime/proc_runtime_instructions_common.c
@@ -188,7 +188,7 @@ param_t * proc_fetch_param(char * param_name, int node) {
 	int offset = proc_param_scan_offset(param_name_copy);
 	if (offset != -1) {
 		int index_length = snprintf(NULL, 0, "%d", offset);
-		param_name_copy[strlen(param_name_copy) - index_length + 1] = '\0';
+		param_name_copy[strlen(param_name_copy) - (index_length + 2)] = '\0';
 	}
 
 	csp_iface_t * ifaces = csp_iflist_get();


### PR DESCRIPTION
Fixes problem with *failed to fetch* error when accessing arrays with an index with multiple digits.

Cause: 
When reading the index of an array param, strtok_r is used to tokenize the string around the '[' character. 
strtok_r then replaces the '[' with a '\0'. As this is done directly on the function input, this introduces an unexpected side-effect. 
This is solved by copying the input and searching on the copy.

The problem does not occur on single digit due to the second bug where the index is supposed to be removed. Here we need to remove the number of digits and both the starting and ending bracket, thus `(index_length+2)`
